### PR TITLE
fix: correct icon URI for sorafujitani

### DIFF
--- a/maintainers.json
+++ b/maintainers.json
@@ -278,7 +278,7 @@
     },
     "github": {
       "id": "sorafujitani",
-      "icon": "https://github.com/sorafujitani/imgs/blob/main/fs0414_dot_image.png",
+      "icon": "https://avatars.githubusercontent.com/u/76100848?v=4",
       "url": "https://github.com/sorafujitani"
     },
     "x": { "url": "https://x.com/sorafujitani" }


### PR DESCRIPTION
## Summary
- GitHub アイコンの URI を正しい avatars.githubusercontent.com の URL に修正

## Test plan
- [ ] maintainers.json のアイコン URL が正しく表示されることを確認